### PR TITLE
meson: use more idiomatic manpage checks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -134,7 +134,7 @@ endif
 
 #####################################################################
 
-xsltproc = find_program('xsltproc', required: get_option('man').allowed())
+xsltproc = find_program('xsltproc', required: get_option('man'))
 
 #####################################################################
 
@@ -159,9 +159,7 @@ subdir('src')
 
 #####################################################################
 
-if xsltproc.found()
-        subdir('man')
-endif
+subdir('man', if_found: xsltproc)
 
 install_data('LICENSE',
              'CODING_STYLE',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 option('man', type : 'feature',
-       value : 'disabled',
+       value : 'auto',
        description : 'build and install man pages')
 
 option('docdir', type : 'string',


### PR DESCRIPTION
The "man" option is defined as a meson feature option. Feature options possess tristate values, but using the .allowed() method casts it to a dual-valued option. Effectively, both "auto" and "enabled" were treated as boolean true, and disabled was treated as boolean false.

find_program was informed that it should always check for the manpage generator, but with a boolean `required:` kwarg, it is nonfatal if not found. That meant configuring with "man=disabled", the manpage would be automatically built if the generator program was available, and with "man=auto" the project would fatally error when configuring but the generator program was not available. This is clearly confusing/wrong, so pass the option value directly instead.

The default value of the option was formerly effectively set to "auto". Change its value to truly be that, so that the default behavior is preserved.

---
Resubmission of https://github.com/mathstuf/systemd-ui-old/pull/6 to this more official repository.